### PR TITLE
Add upcoming events to events page

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,7 +3,9 @@
 class EventsController < ApplicationController
   after_action :ahoy_track, only: :show
 
-  def index; end
+  def index
+    @events = Event.upcoming.order(:begins_at)
+  end
 
   def show
     @event = Event.find_by!(slug: params[:event_slug])

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,0 +1,9 @@
+<div class="pt-10">
+  <h1><%= t('.header') %></h1>
+
+  <div class="flex flex-wrap -mx-3 py-3">
+    <% @events.each do |event| %>
+      <%= render 'shared/event_card', event: event, host: event.place %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/shared/_event_card.html.erb
+++ b/app/views/shared/_event_card.html.erb
@@ -1,9 +1,9 @@
-<%= link_to event_path(event.slug), class: 'w-full sm:w-1/3 flex flex-col p-3'  do %>
+<%= link_to event_path(event.slug), class: 'w-full sm:w-1/3 flex flex-col p-3', id: event.slug do %>
   <div class="bg-white rounded-lg shadow hover:shadow-md overflow-hidden flex-1 flex flex-col">
     <%= cl_image_tag(event.cover_image.key, width: 800, height: 400, crop: :fill, quality: 100) if event.cover_image.attached? %>
     <div class="flex-1 flex flex-col">
       <div class="flex-1 p-4">
-        <p class="text-lg font-medium text-gray-800"><%= l(event.date, format: :medium).capitalize %></p>
+        <p class="text-lg font-medium text-gray-800"><%= l(event.begins_at, format: :medium).capitalize %></p>
         <h3 class="mb-2 text-2xl"><%= event.name %></h3>
         <p class="text-gray-700 text-base"><%= event.short_description %> </p>
       </div>

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -16,7 +16,7 @@ da:
         add_place: Tilføj sted
   date:
     formats:
-      medium: "%A d. %d. %B"
+      medium: "%A d. %d. %B kl. %R"
       long: "%A d. %d. %B, %Y"
   devise:
     registrations:
@@ -28,6 +28,8 @@ da:
         sign_up: Opret en
         submit: Log ind
   events:
+    index:
+      header: Begivenheder i København
     show:
       are_you_going: Skal du med?
       details: Detaljer
@@ -137,6 +139,8 @@ da:
       friday: fredag
       saturday: lørdag
       sunday: søndag
+    formats:
+      medium: "%A d. %d. %B kl. %R"
   users_mailer:
     welcome:
       subject: Velkommen til GoTaste

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -10,11 +10,9 @@ FactoryBot.define do
     begins_at { Time.current + 1.day }
     ends_at { Time.current + 1.day + 2.hours }
     short_description { 'MyText' }
-    url { 'MyString' }
+    url { 'http://example.com' }
     price { 9.99 }
 
-    after(:create) do |event|
-      create(:location, locatable: event)
-    end
+    after(:create) { |event| create(:location, locatable: event) }
   end
 end

--- a/spec/system/events_spec.rb
+++ b/spec/system/events_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Events', type: :system do
+  let!(:future_event) { create :event }
+
+  scenario 'Users go from front page, to events, to an event' do
+    visit root_path
+
+    within('nav') { click_link(t('shared.navbar.events')) }
+    click_link(future_event.slug)
+
+    expect(current_path).to eq(event_path(future_event.slug))
+  end
+
+  scenario 'Users can click "find tickets" button and it opens a new window' do
+    visit event_path(future_event.slug)
+
+    new_window = window_opened_by { click_link t('events.show.find_ticket') }
+
+    within_window new_window do
+      expect(current_url).to eq('http://example.com/')
+    end
+  end
+end


### PR DESCRIPTION
Because:
- Users should be able to quickly find all the
upcoming events

This commit:
- Adds upcoming events to the events page
- Adds system tests